### PR TITLE
added check for inline comments

### DIFF
--- a/flake8_truveris/check_truveris.py
+++ b/flake8_truveris/check_truveris.py
@@ -12,6 +12,7 @@ except ImportError:
 
 from flake8_truveris.token import Token
 from flake8_truveris.trailing_commas import get_trailing_comma_errors
+from flake8_truveris.inline_comments import get_inline_comment_errors
 
 
 class CheckTruveris(object):
@@ -60,13 +61,13 @@ class CheckTruveris(object):
         file_tokens = self.get_qa_file_tokens()
         errors = []
 
-        trailing_comma_errors = get_trailing_comma_errors(file_tokens)
-        errors += trailing_comma_errors
+        errors += get_trailing_comma_errors(file_tokens)
+        errors += get_inline_comment_errors(file_tokens)
 
-        for error in trailing_comma_errors:
+        for e in errors:
             yield (
-                error['line'],
-                error['col'],
-                error['message'],
+                e['line'],
+                e['col'],
+                e['message'],
                 type(self),
             )

--- a/flake8_truveris/inline_comments.py
+++ b/flake8_truveris/inline_comments.py
@@ -1,0 +1,23 @@
+import tokenize
+
+
+def get_inline_comment_errors(file_tokens):
+    errors = []
+    token_num = len(file_tokens)
+    index = 0
+    while index < token_num:
+        token = file_tokens[index]
+        if token.type == tokenize.COMMENT:
+            # current token is a comment
+            previous_token = file_tokens[index - 1]
+            if previous_token.type not in (tokenize.NL, tokenize.NEWLINE):
+                # previous token is a not new line therefore comment is inline
+                error_msg = {
+                    "message": "T568 no inline comments",
+                    "line": token.start_row,
+                    "col": token.start_col,
+                }
+                errors.append(error_msg)
+        index += 1
+
+    return errors


### PR DESCRIPTION
The Truveris coding style guide does not allow for inline comments. This change checks for inline comments and produces an error code T568 when it comes across one. 
